### PR TITLE
Cache Voronoi source points.

### DIFF
--- a/Sources/libnoise/Cache.hx
+++ b/Sources/libnoise/Cache.hx
@@ -1,49 +1,45 @@
 package libnoise;
 
-import haxe.macro.Expr;
-
 /**
  * A 3D array of data, used internally.
  */
 class Cache<T> {
 
-	@:noCompletion public var data : Array<Array<Array<T>>> = null;
+	var data : Array<Array<Array<T>>> = null;
 
 	public var empty(get, never) : Bool;
 
-	@:noCompletion public var xMin : Int = 0;
-	@:noCompletion public var yMin : Int = 0;
-	@:noCompletion public var zMin : Int = 0;
-	@:noCompletion public var xMax : Int = -1;
-	@:noCompletion public var yMax : Int = -1;
-	@:noCompletion public var zMax : Int = -1;
+	public var xMin(default, null) : Int = 0;
+	public var yMin(default, null) : Int = 0;
+	public var zMin(default, null) : Int = 0;
+	public var xMax(default, null) : Int = -1;
+	public var yMax(default, null) : Int = -1;
+	public var zMax(default, null) : Int = -1;
 
 	public inline function new() {
 	}
 
 	/**
 	 * Allocates enough space to cache the given region. This will overwrite any existing data.
-	 * @param calculateValue An expression that calculates the value to cache at (`x`, `y`, `z`). The
-	 * expression will have access to `x`, `y`, and `z`, even if the calling function doesn't define them.
 	 */
-	public macro function allocate<T>(self : ExprOf<Cache<T>>, xMin : ExprOf<Int>, yMin : ExprOf<Int>, zMin : ExprOf<Int>, xMax : ExprOf<Int>, yMax : ExprOf<Int>, zMax : ExprOf<Int>, calculateValue : ExprOf<T>) : Expr {
-		return macro {
-			$self.data =
-				[for (x in $xMin...($xMax + 1))
-					[for (y in $yMin...($yMax + 1))
-						[for (z in $zMin...($zMax + 1))
-							$calculateValue
-						]
-					]
-				];
+	public inline function allocate(xMin : Int, yMin : Int, zMin : Int, xMax : Int, yMax : Int, zMax : Int) : Void {
+		data = [];
+		for (x in 0...(xMax - xMin + 1)) {
+			data.push([]);
+			for (y in 0...(yMax - yMin + 1)) {
+				data[x].push([]);
 
-			$self.xMin = $xMin;
-			$self.yMin = $yMin;
-			$self.zMin = $zMin;
-			$self.xMax = $xMax;
-			$self.yMax = $yMax;
-			$self.zMax = $zMax;
+				// `resize()` will insert appropriate default values.
+				data[x][y].resize(zMax - zMin + 1);
+			}
 		}
+
+		this.xMin = xMin;
+		this.yMin = yMin;
+		this.zMin = zMin;
+		this.xMax = xMax;
+		this.yMax = yMax;
+		this.zMax = zMax;
 	}
 
 	public inline function clear() : Void {

--- a/Sources/libnoise/Cache.hx
+++ b/Sources/libnoise/Cache.hx
@@ -1,0 +1,75 @@
+package libnoise;
+
+import haxe.macro.Expr;
+
+/**
+ * A 3D array of data, used internally.
+ */
+class Cache<T> {
+
+	@:noCompletion public var data : Array<Array<Array<T>>> = null;
+
+	public var empty(get, never) : Bool;
+
+	@:noCompletion public var xMin : Int = 0;
+	@:noCompletion public var yMin : Int = 0;
+	@:noCompletion public var zMin : Int = 0;
+	@:noCompletion public var xMax : Int = -1;
+	@:noCompletion public var yMax : Int = -1;
+	@:noCompletion public var zMax : Int = -1;
+
+	public inline function new() {
+	}
+
+	/**
+	 * @param calculateValue An expression that calculates the value to cache at (`x`, `y`, `z`). The
+	 * expression will have access to `x`, `y`, and `z`, even if the calling function doesn't define them.
+	 */
+	public macro function allocate<T>(self : ExprOf<Cache<T>>, xMin : ExprOf<Int>, yMin : ExprOf<Int>, zMin : ExprOf<Int>, xMax : ExprOf<Int>, yMax : ExprOf<Int>, zMax : ExprOf<Int>, calculateValue : ExprOf<T>) : Expr {
+		return macro {
+			$self.data =
+				[for (x in $xMin...($xMax + 1))
+					[for (y in $yMin...($yMax + 1))
+						[for (z in $zMin...($zMax + 1))
+							$calculateValue
+						]
+					]
+				];
+
+			$self.xMin = $xMin;
+			$self.yMin = $yMin;
+			$self.zMin = $zMin;
+			$self.xMax = $xMax;
+			$self.yMax = $yMax;
+			$self.zMax = $zMax;
+		}
+	}
+
+	public inline function clear() : Void {
+		data = null;
+		xMin = 0;
+		xMax = -1;
+	}
+
+	public inline function inBounds(x : Int, y : Int, z : Int) : Bool {
+		return x >= xMin && x <= xMax && y >= yMin && y <= yMax && z >= zMin && z <= zMax;
+	}
+
+	/**
+	 * Precondition: (`x`, `y`, `z`) is in bounds.
+	 */
+	public inline function get(x : Int, y : Int, z : Int) : T {
+		return data[x - xMin][y - yMin][z - zMin];
+	}
+
+	/**
+	 * Precondition: (`x`, `y`, `z`) is in bounds.
+	 */
+	public inline function set(x : Int, y : Int, z : Int, value : T) : T {
+		return data[x - xMin][y - yMin][z - zMin] = value;
+	}
+
+	inline function get_empty() : Bool {
+		return data == null;
+	}
+}

--- a/Sources/libnoise/Cache.hx
+++ b/Sources/libnoise/Cache.hx
@@ -22,6 +22,7 @@ class Cache<T> {
 	}
 
 	/**
+	 * Allocates enough space to cache the given region. This will overwrite any existing data.
 	 * @param calculateValue An expression that calculates the value to cache at (`x`, `y`, `z`). The
 	 * expression will have access to `x`, `y`, and `z`, even if the calling function doesn't define them.
 	 */

--- a/Sources/libnoise/ModuleBase.hx
+++ b/Sources/libnoise/ModuleBase.hx
@@ -26,6 +26,39 @@ class ModuleBase {
 		return 0;
 	}
 
+	/**
+	 * Caches values within the given region of space. Certain classes will use this to improve performance
+	 * when you call `getValue()` within that region.
+	 * 
+	 * Only one region can be cached at a time. Trying to cache another will overwrite the first. To avoid
+	 * this, create a new module instance if `isCacheEmpty()` returns false.
+	 */
+	public function cache(xMin : Float, yMin : Float, zMin : Float, xMax : Float, yMax : Float, zMax : Float) : Void {
+		if (modules != null) {
+			for (module in modules) {
+				module.cache(xMin, yMin, zMin, xMax, yMax, zMax);
+			}
+		}
+	}
+
+	public function isCacheEmpty() : Bool {
+		if (modules != null) {
+			for (module in modules) {
+				if (!module.isCacheEmpty()) {
+					return false;
+				}
+			}
+		}
+		
+		return true;
+	}
+
+	public function clearCache() : Void {
+		for (module in modules) {
+			module.clearCache();
+		}
+	}
+
 	//TODO: see if dispose functions need to be implemented (cf https://github.com/ricardojmendez/LibNoise.Unity/blob/master/ModuleBase.cs#L158)
 
 }

--- a/Sources/libnoise/generator/Voronoi.hx
+++ b/Sources/libnoise/generator/Voronoi.hx
@@ -96,10 +96,17 @@ class Voronoi extends ModuleBase {
 			Math.floor(zMin * frequency) - 2,
 			Math.floor(xMax * frequency) + 2,
 			Math.floor(yMax * frequency) + 2,
-			Math.floor(zMax * frequency) + 2,
-			new Site(x + Utils.ValueNoise3D(x, y, z, seed),
-				y + Utils.ValueNoise3D(x, y, z, seed + 1),
-				z + Utils.ValueNoise3D(z, y, z, seed + 2)));
+			Math.floor(zMax * frequency) + 2);
+
+		for(z in sites.zMin...(sites.zMax + 1)) {
+			for(y in sites.yMin...(sites.yMax + 1)) {
+				for(x in sites.xMin...(sites.xMax + 1)) {
+					sites.set(x, y, z, new Site(x + Utils.ValueNoise3D(x, y, z, seed),
+						y + Utils.ValueNoise3D(x, y, z, seed + 1),
+						z + Utils.ValueNoise3D(z, y, z, seed + 2)));
+				}
+			}
+		}
 	}
 
 	@:inheritDoc

--- a/Sources/libnoise/generator/Voronoi.hx
+++ b/Sources/libnoise/generator/Voronoi.hx
@@ -1,7 +1,10 @@
 package libnoise.generator;
 
+import libnoise.Cache;
+
 class Voronoi extends ModuleBase {
 
+	var pointCache : Cache<Vector>;
 	var frequency : Float;
 	var displacement : Float;
 	var seed : Int;
@@ -12,6 +15,7 @@ class Voronoi extends ModuleBase {
 		this.displacement = displacement;
 		this.seed = seed;
 		this.distance = distance;
+		pointCache = new Cache();
 		super(0);
 	}
 
@@ -19,9 +23,9 @@ class Voronoi extends ModuleBase {
 		x *= frequency;
 		y *= frequency;
 		z *= frequency;
-		var xi = (x > 0.0 ? Std.int(x) : Std.int(x - 1));
-		var iy = (y > 0.0 ? Std.int(y) : Std.int(y - 1));
-		var iz = (z > 0.0 ? Std.int(z) : Std.int(z - 1));
+		var xi = Math.floor(x);
+		var iy = Math.floor(y);
+		var iz = Math.floor(z);
 		var md = 2147483647.0;
 		var xc : Float = 0;
 		var yc : Float = 0;
@@ -29,9 +33,19 @@ class Voronoi extends ModuleBase {
 		for (zcu in (iz - 2)...(iz + 3)) {
 			for (ycu in (iy - 2)...(iy + 3)) {
 				for (xcu in (xi - 2)...(xi + 3)) {
-					var xp = xcu + Utils.ValueNoise3D(xcu, ycu, zcu, seed);
-					var yp = ycu + Utils.ValueNoise3D(xcu, ycu, zcu, seed + 1);
-					var zp = zcu + Utils.ValueNoise3D(xcu, ycu, zcu, seed + 2);
+					var xp : Float;
+					var yp : Float;
+					var zp : Float;
+					if (pointCache.inBounds(xcu, ycu, zcu)) {
+						var p : Vector = pointCache.get(xcu, ycu, zcu);
+						xp = p.x;
+						yp = p.y;
+						zp = p.z;
+					} else {
+						xp = xcu + Utils.ValueNoise3D(xcu, ycu, zcu, seed);
+						yp = ycu + Utils.ValueNoise3D(xcu, ycu, zcu, seed + 1);
+						zp = zcu + Utils.ValueNoise3D(xcu, ycu, zcu, seed + 2);
+					}
 					var xd = xp - x;
 					var yd = yp - y;
 					var zd = zp - z;
@@ -57,5 +71,37 @@ class Voronoi extends ModuleBase {
 		}
 		return v + (displacement * Utils.ValueNoise3D(Std.int(Math.floor(xc)), Std.int(Math.floor(yc)),
 		Std.int(Math.floor(zc)), 0));
+	}
+
+	@:inheritDoc
+	public override function cache(xMin : Float, yMin : Float, zMin : Float, xMax : Float, yMax : Float, zMax : Float) {
+		var xMinInt : Int = Math.floor(xMin * frequency) - 2;
+		var yMinInt : Int = Math.floor(yMin * frequency) - 2;
+		var zMinInt : Int = Math.floor(zMin * frequency) - 2;
+		var xMaxInt : Int = Math.floor(xMax * frequency) + 2;
+		var yMaxInt : Int = Math.floor(yMax * frequency) + 2;
+		var zMaxInt : Int = Math.floor(zMax * frequency) + 2;
+
+		pointCache.allocate(xMinInt, yMinInt, zMinInt, xMaxInt, yMaxInt, zMaxInt,
+			new Vector(x + Utils.ValueNoise3D(x, y, z, seed),
+				y + Utils.ValueNoise3D(x, y, z, seed + 1),
+				z + Utils.ValueNoise3D(z, y, z, seed + 2)));
+	}
+
+	@:inheritDoc
+	public override function clearCache() : Void {
+		pointCache.clear();
+	}
+}
+
+class Vector {
+	public var x : Float;
+	public var y : Float;
+	public var z : Float;
+
+	public inline function new(x : Float, y : Float, z : Float) {
+		this.x = x;
+		this.y = y;
+		this.z = z;
 	}
 }


### PR DESCRIPTION
This requires some input from the user but seriously improves performance. Basically it looks like this:

```haxe
var module = new Voronoi(0.02, 1, 234, false);
module.cache(0, 0, 0, 100, 100, 100);

// The cached area is faster to calculate:
module.getValue(10, 20, 30);
module.getValue(50, 50, 50);
module.getValue(100, 0, 100);
module.getValue(40, 50, 60);

// You can still get values outside the area, but they aren't faster:
module.getValue(200, 0, 0);
module.getValue(-1, -1, -1);
```

Tested primarily in HashLink and HTML5. In HashLink it shaves off about 33% of the time required, while in HTML5 it shaves off about 66%.